### PR TITLE
Be aware of `container.env.valueFrom` and `container.envFrom`

### DIFF
--- a/eci.go
+++ b/eci.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
-	"github.com/virtual-kubelet/alibabacloud-eci/eci"
 	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/manager"
@@ -27,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/virtual-kubelet/alibabacloud-eci/eci"
 )
 
 // The service account secret mount path.
@@ -175,7 +176,7 @@ func NewECIProvider(config string, rm *manager.ResourceManager, nodeName, operat
 // CreatePod accepts a Pod definition and creates
 // an ECI deployment
 func (p *ECIProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
-	//Ignore daemonSet Pod
+	// Ignore daemonSet Pod
 	if pod != nil && pod.OwnerReferences != nil && len(pod.OwnerReferences) != 0 && pod.OwnerReferences[0].Kind == "DaemonSet" {
 		msg := fmt.Sprintf("Skip to create DaemonSet pod %q", pod.Name)
 		log.G(ctx).WithField("Method", "CreatePod").Info(msg)
@@ -480,9 +481,6 @@ func (p *ECIProvider) getImagePullSecrets(pod *v1.Pod) ([]eci.ImageRegistryCrede
 		if secret == nil {
 			return nil, fmt.Errorf("error getting image pull secret")
 		}
-		// TODO: Check if secret type is v1.SecretTypeDockercfg and use DockerConfigKey instead of hardcoded value
-		// TODO: Check if secret type is v1.SecretTypeDockerConfigJson and use DockerConfigJsonKey to determine if it's in json format
-		// TODO: Return error if it's not one of these two types
 		switch secret.Type {
 		case v1.SecretTypeDockercfg:
 			ips, err = readDockerCfgSecret(secret, ips)

--- a/fieldpath.go
+++ b/fieldpath.go
@@ -1,0 +1,94 @@
+package alibabacloud
+
+// Simply copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/fieldpath/fieldpath.go
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// FormatMap formats map[string]string to a string.
+func FormatMap(m map[string]string) (fmtStr string) {
+	// output with keys in sorted order to provide stable output
+	keys := sets.NewString()
+	for key := range m {
+		keys.Insert(key)
+	}
+	for _, key := range keys.List() {
+		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
+	}
+	fmtStr = strings.TrimSuffix(fmtStr, "\n")
+
+	return
+}
+
+// ExtractFieldPathAsString extracts the field from the given object
+// and returns it as a string.  The object must be a pointer to an
+// API type.
+func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+
+	if path, subscript, ok := SplitMaybeSubscriptedPath(fieldPath); ok {
+		switch path {
+		case "metadata.annotations":
+			if errs := validation.IsQualifiedName(strings.ToLower(subscript)); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetAnnotations()[subscript], nil
+		case "metadata.labels":
+			if errs := validation.IsQualifiedName(subscript); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetLabels()[subscript], nil
+		default:
+			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
+		}
+	}
+
+	switch fieldPath {
+	case "metadata.annotations":
+		return FormatMap(accessor.GetAnnotations()), nil
+	case "metadata.labels":
+		return FormatMap(accessor.GetLabels()), nil
+	case "metadata.name":
+		return accessor.GetName(), nil
+	case "metadata.namespace":
+		return accessor.GetNamespace(), nil
+	case "metadata.uid":
+		return string(accessor.GetUID()), nil
+	}
+
+	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+}
+
+// SplitMaybeSubscriptedPath checks whether the specified fieldPath is
+// subscripted, and
+//  - if yes, this function splits the fieldPath into path and subscript, and
+//    returns (path, subscript, true).
+//  - if no, this function returns (fieldPath, "", false).
+//
+// Example inputs and outputs:
+//  - "metadata.annotations['myKey']" --> ("metadata.annotations", "myKey", true)
+//  - "metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c", true)
+//  - "metadata.labels['']"           --> ("metadata.labels", "", true)
+//  - "metadata.labels"               --> ("metadata.labels", "", false)
+func SplitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, "", false
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, "", false
+	}
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
+	}
+	return parts[0], parts[1], true
+}


### PR DESCRIPTION
Resolves #1 

This PR aims to support `container.env.valueFrom` and `container.envFrom`, the code is basically copied from `kubelet`, but some problems remain unresolved:

1. `status.podIP`: I am not sure how to get the pod IP before its creation.
2. `ValueFrom.ResourceFieldRef`: I have noticed that the resource requests and limits specified in pod are not the actual values in eci, not sure whether it make ssense to pass the inaccurate values to pod.
3. should we provide some helper functions in, let's say `virtual-kubelet` or `api-machinery/pkg/util`, to extract the actual values of environment variables? so that these copy-pastes could be avoided.